### PR TITLE
fix: items appended rather than reloaded fresh after switching page

### DIFF
--- a/src/views/Emotion.vue
+++ b/src/views/Emotion.vue
@@ -265,18 +265,20 @@ export default {
                     this.pages = res.data.data.pages;
 
                     this.loadLike();
-                    this.$nextTick(() => {
-                        this.$refs.waterfall.repaints(this.page * this.per, 1);
-                    });
                 })
                 .then(() => {
                     this.loading = true;
 
                     // let result = this.$refs.waterfall.repaints()
-                    this.$refs.waterfall.onRender = (res) => {
-                        this.loading = false;
-                        console.log("waterfall渲染完毕", res);
-                    };
+                    if(this.$refs.waterfall) {      // Waterfall is sometimes undefined, why???
+                        this.$refs.waterfall.onRender = (res) => {
+                            this.loading = false;
+                            console.log("waterfall渲染完毕", res);
+                        };
+                        this.$nextTick(() => {
+                                this.$refs.waterfall.repaints(this.page * this.per, 1);
+                        });
+                    }
                 })
                 .finally(() => {
                     this.loading = false;
@@ -382,11 +384,13 @@ export default {
         reset_keys: {
             deep: true,
             handler: function () {
+                this.appendMode = false;
                 this.page = 1;
             },
         },
         // 类别重置
         search: function () {
+            this.appendMode = false;
             this.type = "all";
         },
         // emotions: {


### PR DESCRIPTION
When another page is loaded by clicking the "load more" button, `appendMode` got set which makes the new items being appended to the current items. However if we then change the filter, the filtered result would still be appended rather than replacing the current content, which might be unfavorable. 